### PR TITLE
Make Example a non-native JS class

### DIFF
--- a/Example.scala
+++ b/Example.scala
@@ -1,11 +1,11 @@
 package demo
 
 import scalajs.js
-import scala.scalajs.js.annotation.{JSExportTopLevel, JSExportAll}
+import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("Example")
-@JSExportAll
-class Example {
+@ScalaJSDefined
+class Example extends js.Object {
 
   def receive(x: Any): Unit ={
     println(s"overload me please $x")


### PR DESCRIPTION
This is necessary so that JS is allowed to inherit from it.